### PR TITLE
feat: update to consume base-ocp-vpc v3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You need the following permissions to run this module.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.2.3 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.8.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.49.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.51.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.16.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.2.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
@@ -122,7 +122,7 @@ You need the following permissions to run this module.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_observability_agents"></a> [observability\_agents](#module\_observability\_agents) | git::https://github.com/terraform-ibm-modules/terraform-ibm-observability-agents | v1.0.0 |
-| <a name="module_ocp_base"></a> [ocp\_base](#module\_ocp\_base) | git::https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc.git | v2.0.0 |
+| <a name="module_ocp_base"></a> [ocp\_base](#module\_ocp\_base) | git::https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc.git | v3.3.2 |
 
 ## Resources
 
@@ -132,6 +132,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | Optional list of access management tags to add to the OCP Cluster created by this module. | `list(string)` | `[]` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name to give the OCP cluster provisioned by the module. | `string` | n/a | yes |
 | <a name="input_cluster_ready_when"></a> [cluster\_ready\_when](#input\_cluster\_ready\_when) | The cluster is ready when one of the following: MasterNodeReady (not recommended), OneWorkerNodeReady, Normal, IngressReady | `string` | `"IngressReady"` | no |
 | <a name="input_cluster_tags"></a> [cluster\_tags](#input\_cluster\_tags) | List of metadata labels to add to cluster. | `list(string)` | `[]` | no |

--- a/examples/end-to-end-example/main.tf
+++ b/examples/end-to-end-example/main.tf
@@ -94,6 +94,7 @@ module "ocp_all_inclusive" {
   worker_pools                       = var.worker_pools
   ocp_version                        = var.ocp_version
   cluster_tags                       = var.resource_tags
+  access_tags                        = var.access_tags
   existing_key_protect_instance_guid = module.key_protect_all_inclusive.key_protect_guid
   existing_key_protect_root_key_id   = module.key_protect_all_inclusive.keys["${local.key_ring_name}.${local.key_name}"].key_id
   logdna_instance_name               = module.observability_instances.logdna_name

--- a/examples/end-to-end-example/variables.tf
+++ b/examples/end-to-end-example/variables.tf
@@ -34,6 +34,12 @@ variable "resource_tags" {
   default     = []
 }
 
+variable "access_tags" {
+  type        = list(string)
+  description = "Optional list of access management tags to add to the OCP Cluster created by this module."
+  default     = []
+}
+
 variable "worker_pools" {
   type = list(object({
     subnet_prefix     = string

--- a/examples/end-to-end-example/version.tf
+++ b/examples/end-to-end-example/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.49.0"
+      version = "1.51.0"
     }
     helm = {
       version = "2.8.0"

--- a/main.tf
+++ b/main.tf
@@ -20,12 +20,13 @@ locals {
 }
 
 module "ocp_base" {
-  source                          = "git::https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc.git?ref=v2.0.0"
+  source                          = "git::https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc.git?ref=v3.3.2"
   cluster_name                    = var.cluster_name
   ocp_version                     = var.ocp_version
   resource_group_id               = var.resource_group_id
   region                          = var.region
   tags                            = var.cluster_tags
+  access_tags                     = var.access_tags
   force_delete_storage            = var.force_delete_storage
   vpc_id                          = var.vpc_id
   vpc_subnets                     = var.vpc_subnets

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -1,6 +1,28 @@
 {
   "path": ".",
   "variables": {
+    "access_tags": {
+      "name": "access_tags",
+      "type": "list(string)",
+      "description": "Optional list of access management tags to add to the OCP Cluster created by this module.",
+      "default": [],
+      "source": [
+        "module.ocp_base.ibm_resource_tag.cluster_access_tag.count",
+        "module.ocp_base.ibm_resource_tag.cluster_access_tag.tags",
+        "module.ocp_base.ibm_resource_tag.cos_access_tag.tags"
+      ],
+      "pos": {
+        "filename": "variables.tf",
+        "line": 107
+      },
+      "min_length": 1,
+      "max_length": 128,
+      "matches": "^[A-Za-z0-9:_ .-]+$",
+      "computed": true,
+      "elem": {
+        "type": "TypeString"
+      }
+    },
     "cluster_name": {
       "name": "cluster_name",
       "type": "string",
@@ -27,7 +49,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 107
+        "line": 113
       }
     },
     "cluster_tags": {
@@ -60,7 +82,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 144
+        "line": 150
       }
     },
     "disable_public_endpoint": {
@@ -70,11 +92,12 @@
       "default": false,
       "source": [
         "module.ocp_base.ibm_container_vpc_cluster.autoscaling_cluster.disable_public_service_endpoint",
-        "module.ocp_base.ibm_container_vpc_cluster.cluster.disable_public_service_endpoint"
+        "module.ocp_base.ibm_container_vpc_cluster.cluster.disable_public_service_endpoint",
+        "module.ocp_base.kubernetes_config_map_v1_data.set_autoscaling.count"
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 120
+        "line": 126
       }
     },
     "existing_cos_id": {
@@ -86,7 +109,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 150
+        "line": 156
       }
     },
     "existing_key_protect_instance_guid": {
@@ -95,7 +118,7 @@
       "description": "The GUID of an existing Key Protect instance which will be used for cluster encryption. If no value passed, cluster data is stored in the Kubernetes etcd, which ends up on the local disk of the Kubernetes master (not recommended).",
       "pos": {
         "filename": "variables.tf",
-        "line": 160
+        "line": 166
       }
     },
     "existing_key_protect_root_key_id": {
@@ -104,7 +127,7 @@
       "description": "The Key ID of a root key, existing in the Key Protect instance passed in var.existing_key_protect_instance_guid, which will be used to encrypt the data encryption keys (DEKs) which are then used to encrypt the secrets in the cluster. Required if value passed for var.existing_key_protect_instance_guid.",
       "pos": {
         "filename": "variables.tf",
-        "line": 166
+        "line": 172
       }
     },
     "force_delete_storage": {
@@ -118,7 +141,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 132
+        "line": 138
       }
     },
     "ibmcloud_api_key": {
@@ -140,14 +163,19 @@
       "type": "bool",
       "description": "Enable if using worker autoscaling. Stops Terraform managing worker count",
       "default": false,
+      "required": true,
       "source": [
         "module.ocp_base.ibm_container_vpc_cluster.autoscaling_cluster.count",
-        "module.ocp_base.ibm_container_vpc_cluster.cluster.count"
+        "module.ocp_base.ibm_container_vpc_cluster.cluster.count",
+        "module.ocp_base.ibm_resource_tag.cluster_access_tag.resource_id"
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 182
-      }
+        "line": 188
+      },
+      "min_length": 1,
+      "max_length": 1024,
+      "matches": "^crn:v1(:[a-zA-Z0-9 \\-\\._~\\*\\+,;=!$\u0026'\\(\\)\\/\\?#\\[\\]@]*){8}$|^[0-9]+$"
     },
     "key_protect_use_private_endpoint": {
       "name": "key_protect_use_private_endpoint",
@@ -156,7 +184,7 @@
       "default": true,
       "pos": {
         "filename": "variables.tf",
-        "line": 172
+        "line": 178
       }
     },
     "logdna_agent_version": {
@@ -168,7 +196,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 211
+        "line": 217
       }
     },
     "logdna_ingestion_key": {
@@ -181,7 +209,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 198
+        "line": 204
       }
     },
     "logdna_instance_name": {
@@ -194,7 +222,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 192
+        "line": 198
       }
     },
     "logdna_resource_group_id": {
@@ -203,7 +231,7 @@
       "description": "Resource group id that the LogDNA instance is in. If left at null, the value of var.resource_group_id will be used.",
       "pos": {
         "filename": "variables.tf",
-        "line": 205
+        "line": 211
       }
     },
     "ocp_entitlement": {
@@ -217,7 +245,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 126
+        "line": 132
       }
     },
     "ocp_version": {
@@ -238,12 +266,14 @@
       "description": "The IBM Cloud region where all resources will be provisioned.",
       "required": true,
       "source": [
-        "module.ocp_base"
+        "module.ocp_base.data.ibm_container_cluster_versions.cluster_versions.region"
       ],
       "pos": {
         "filename": "variables.tf",
         "line": 16
-      }
+      },
+      "cloud_data_type": "region",
+      "deprecated": "This field is deprecated"
     },
     "resource_group_id": {
       "name": "resource_group_id",
@@ -254,11 +284,13 @@
         "module.observability_agents.data.ibm_container_cluster_config.cluster_config.resource_group_id",
         "module.observability_agents.data.ibm_container_vpc_cluster.cluster.resource_group_id",
         "module.ocp_base.data.ibm_container_cluster_config.cluster_config.resource_group_id",
+        "module.ocp_base.data.ibm_container_cluster_versions.cluster_versions.resource_group_id",
+        "module.ocp_base.ibm_container_addons.addons.resource_group_id",
         "module.ocp_base.ibm_container_vpc_cluster.autoscaling_cluster.resource_group_id",
         "module.ocp_base.ibm_container_vpc_cluster.cluster.resource_group_id",
         "module.ocp_base.ibm_container_vpc_worker_pool.autoscaling_pool.resource_group_id",
         "module.ocp_base.ibm_container_vpc_worker_pool.pool.resource_group_id",
-        "module.ocp_base.ibm_resource_instance.cos_instance.resource_group_id"
+        "module.ocp_base.module.cos_instance.ibm_resource_instance.cos_instance.resource_group_id"
       ],
       "pos": {
         "filename": "variables.tf",
@@ -281,7 +313,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 227
+        "line": 233
       }
     },
     "sysdig_agent_version": {
@@ -293,7 +325,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 240
+        "line": 246
       }
     },
     "sysdig_instance_name": {
@@ -306,7 +338,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 221
+        "line": 227
       }
     },
     "sysdig_resource_group_id": {
@@ -315,7 +347,7 @@
       "description": "Resource group id that the Sysdig instance is in. If left at null, the value of var.resource_group_id will be used.",
       "pos": {
         "filename": "variables.tf",
-        "line": 234
+        "line": 240
       }
     },
     "use_existing_cos": {
@@ -324,11 +356,12 @@
       "description": "COS is required to back up the OpenShift internal registry. Set this to true and pass a value for var.existing_cos_id if you want to use an existing COS instance.",
       "default": false,
       "source": [
-        "module.ocp_base.ibm_resource_instance.cos_instance.count"
+        "module.ocp_base.ibm_resource_tag.cos_access_tag.count",
+        "module.ocp_base.module.cos_instance"
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 138
+        "line": 144
       }
     },
     "vpc_id": {
@@ -482,7 +515,8 @@
         "filename": "outputs.tf",
         "line": 40
       },
-      "type": "string"
+      "type": "string",
+      "cloud_data_type": "region"
     },
     "resource_group_id": {
       "name": "resource_group_id",
@@ -531,7 +565,7 @@
     "ibm": {
       "source": "ibm-cloud/ibm",
       "version_constraints": [
-        "\u003e= 1.49.0"
+        "\u003e= 1.51.0"
       ]
     },
     "kubernetes": {
@@ -674,13 +708,14 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 66
+        "line": 67
       }
     },
     "ocp_base": {
       "name": "ocp_base",
-      "source": "git::https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc.git?ref=v2.0.0",
+      "source": "git::https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc.git?ref=v3.3.2",
       "attributes": {
+        "access_tags": "access_tags",
         "cluster_name": "cluster_name",
         "cluster_ready_when": "cluster_ready_when",
         "cos_name": "cos_name",
@@ -700,6 +735,21 @@
         "worker_pools": "worker_pools"
       },
       "managed_resources": {
+        "ibm_container_addons.addons": {
+          "mode": "managed",
+          "type": "ibm_container_addons",
+          "name": "addons",
+          "attributes": {
+            "resource_group_id": "resource_group_id"
+          },
+          "provider": {
+            "name": "ibm"
+          },
+          "pos": {
+            "filename": ".terraform/modules/ocp_base/main.tf",
+            "line": 360
+          }
+        },
         "ibm_container_vpc_cluster.autoscaling_cluster": {
           "mode": "managed",
           "type": "ibm_container_vpc_cluster",
@@ -720,7 +770,7 @@
           },
           "pos": {
             "filename": ".terraform/modules/ocp_base/main.tf",
-            "line": 112
+            "line": 133
           }
         },
         "ibm_container_vpc_cluster.cluster": {
@@ -743,7 +793,7 @@
           },
           "pos": {
             "filename": ".terraform/modules/ocp_base/main.tf",
-            "line": 51
+            "line": 71
           }
         },
         "ibm_container_vpc_worker_pool.autoscaling_pool": {
@@ -759,7 +809,7 @@
           },
           "pos": {
             "filename": ".terraform/modules/ocp_base/main.tf",
-            "line": 244
+            "line": 284
           }
         },
         "ibm_container_vpc_worker_pool.pool": {
@@ -775,35 +825,70 @@
           },
           "pos": {
             "filename": ".terraform/modules/ocp_base/main.tf",
-            "line": 210
+            "line": 243
           }
         },
-        "ibm_resource_instance.cos_instance": {
+        "ibm_resource_tag.cluster_access_tag": {
           "mode": "managed",
-          "type": "ibm_resource_instance",
-          "name": "cos_instance",
+          "type": "ibm_resource_tag",
+          "name": "cluster_access_tag",
           "attributes": {
-            "count": "use_existing_cos",
-            "resource_group_id": "resource_group_id"
+            "count": "access_tags",
+            "resource_id": "ignore_worker_pool_size_changes",
+            "tags": "access_tags"
           },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": ".terraform/modules/ocp_base/main.tf",
-            "line": 37
+            "line": 197
+          }
+        },
+        "ibm_resource_tag.cos_access_tag": {
+          "mode": "managed",
+          "type": "ibm_resource_tag",
+          "name": "cos_access_tag",
+          "attributes": {
+            "count": "use_existing_cos",
+            "tags": "access_tags"
+          },
+          "provider": {
+            "name": "ibm"
+          },
+          "pos": {
+            "filename": ".terraform/modules/ocp_base/main.tf",
+            "line": 60
+          }
+        },
+        "kubernetes_config_map_v1_data.set_autoscaling": {
+          "mode": "managed",
+          "type": "kubernetes_config_map_v1_data",
+          "name": "set_autoscaling",
+          "attributes": {
+            "count": "disable_public_endpoint"
+          },
+          "provider": {
+            "name": "kubernetes"
+          },
+          "pos": {
+            "filename": ".terraform/modules/ocp_base/main.tf",
+            "line": 397
           }
         },
         "null_resource.confirm_network_healthy": {
           "mode": "managed",
           "type": "null_resource",
           "name": "confirm_network_healthy",
+          "attributes": {
+            "count": "verify_worker_network_readiness"
+          },
           "provider": {
             "name": "null"
           },
           "pos": {
             "filename": ".terraform/modules/ocp_base/main.tf",
-            "line": 297
+            "line": 344
           }
         },
         "null_resource.reset_api_key": {
@@ -815,7 +900,19 @@
           },
           "pos": {
             "filename": ".terraform/modules/ocp_base/main.tf",
-            "line": 186
+            "line": 218
+          }
+        },
+        "time_sleep.wait_operators": {
+          "mode": "managed",
+          "type": "time_sleep",
+          "name": "wait_operators",
+          "provider": {
+            "name": "time"
+          },
+          "pos": {
+            "filename": ".terraform/modules/ocp_base/main.tf",
+            "line": 379
           }
         }
       },
@@ -825,6 +922,7 @@
           "type": "ibm_container_cluster_config",
           "name": "cluster_config",
           "attributes": {
+            "count": "verify_worker_network_readiness",
             "resource_group_id": "resource_group_id"
           },
           "provider": {
@@ -832,19 +930,23 @@
           },
           "pos": {
             "filename": ".terraform/modules/ocp_base/main.tf",
-            "line": 200
+            "line": 232
           }
         },
         "data.ibm_container_cluster_versions.cluster_versions": {
           "mode": "data",
           "type": "ibm_container_cluster_versions",
           "name": "cluster_versions",
+          "attributes": {
+            "region": "region",
+            "resource_group_id": "resource_group_id"
+          },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": ".terraform/modules/ocp_base/main.tf",
-            "line": 35
+            "line": 38
           }
         }
       },
@@ -921,7 +1023,8 @@
             "filename": ".terraform/modules/ocp_base/outputs.tf",
             "line": 43
           },
-          "type": "string"
+          "type": "string",
+          "cloud_data_type": "region"
         },
         "resource_group_id": {
           "name": "resource_group_id",

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -4,11 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/common"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
 
 const basicExampleTerraformDir = "examples/end-to-end-example"
 const resourceGroup = "geretain-test-ocp-all-inclusive"
+
+const yamlLocation = "../common-dev-assets/common-go-assets/common-permanent-resources.yaml"
+
+var permanentResources map[string]interface{}
 
 func setupOptions(t *testing.T, prefix string, terraformVars map[string]interface{}) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
@@ -38,6 +43,7 @@ func testRunComplete(t *testing.T, version string) {
 
 	terraformVars := map[string]interface{}{
 		"ocp_version": version,
+		"access_tags": permanentResources["accessTags"],
 	}
 	options := setupOptions(t, "ocp-all-inc", terraformVars)
 

--- a/variables.tf
+++ b/variables.tf
@@ -104,6 +104,12 @@ variable "cluster_tags" {
   default     = []
 }
 
+variable "access_tags" {
+  type        = list(string)
+  description = "Optional list of access management tags to add to the OCP Cluster created by this module."
+  default     = []
+}
+
 variable "cluster_ready_when" {
   type        = string
   description = "The cluster is ready when one of the following: MasterNodeReady (not recommended), OneWorkerNodeReady, Normal, IngressReady"

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.49.0"
+      version = ">= 1.51.0"
     }
     # tflint-ignore: terraform_unused_required_providers
     external = {


### PR DESCRIPTION
### Description
Update to consume the latest version of the base-ocp-vpc module and utilize the access tags feature.

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [ ] Bug fix
- [x] New feature
- [x] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [x] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Update to consume [terraform-ibm-base-ocp-vpc:v3.2.2](https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc) and add access tags support for the OCP cluster instance.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
