### PR TITLE
Fixed end-to-end example to allow ingress healthcheck traffic

### DIFF
--- a/examples/end-to-end-example/README.md
+++ b/examples/end-to-end-example/README.md
@@ -3,6 +3,7 @@
 An end-to-end example that will:
 - Create a new resource group (if existing one is not passed in).
 - Provision a VPC in the given resource group and region.
+- Define ACLs to allow inbound and outboud traffic from/to Ingress Operator to correctly report cluster ingress status
 - Provision Log Analysis and Cloud Monitoring instances in the given resource group and region.
 - Provision a Key Protect instance in the given resource group and region and create a new key ring and key in the instance
 - Call the ocp-all-inclusive-module to do the following:


### PR DESCRIPTION
### Description

Modified end-to-end example by:
- Adding ACLs to VPC to allow the inbound and outbound traffic to/from ingress operator to report the ingress status.
- Added public gateways to all the zones

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Modified end-to-end example by adding ACLs to VPC to allow the inbound and outbound traffic to/from ingress operator to report the ingress status and adding public gateways to all the zones

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [X] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
