### PR TITLE
feat: add wait for kms feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You need the following permissions to run this module.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.2.3, < 3.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.8.0, < 3.0.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.64.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.66.0, < 2.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.16.1, < 3.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.2.3, < 3.0.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1, < 4.0.0 |
@@ -128,7 +128,7 @@ You need the following permissions to run this module.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_observability_agents"></a> [observability\_agents](#module\_observability\_agents) | terraform-ibm-modules/observability-agents/ibm | 1.26.0 |
-| <a name="module_ocp_base"></a> [ocp\_base](#module\_ocp\_base) | terraform-ibm-modules/base-ocp-vpc/ibm | 3.25.5 |
+| <a name="module_ocp_base"></a> [ocp\_base](#module\_ocp\_base) | terraform-ibm-modules/base-ocp-vpc/ibm | 3.27.1 |
 
 ### Resources
 
@@ -167,10 +167,10 @@ No resources.
 | <a name="input_existing_kms_instance_guid"></a> [existing\_kms\_instance\_guid](#input\_existing\_kms\_instance\_guid) | The GUID of an existing KMS instance which will be used for cluster encryption. If no value passed, cluster data is stored in the Kubernetes etcd, which ends up on the local disk of the Kubernetes master (not recommended). | `string` | `null` | no |
 | <a name="input_existing_kms_root_key_id"></a> [existing\_kms\_root\_key\_id](#input\_existing\_kms\_root\_key\_id) | The Key ID of a root key, existing in the KMS instance passed in var.existing\_kms\_instance\_guid, which will be used to encrypt the data encryption keys (DEKs) which are then used to encrypt the secrets in the cluster. Required if value passed for var.existing\_kms\_instance\_guid. | `string` | `null` | no |
 | <a name="input_force_delete_storage"></a> [force\_delete\_storage](#input\_force\_delete\_storage) | Delete attached storage when destroying the cluster - Default: false | `bool` | `false` | no |
-| <a name="input_ibmcloud_api_key"></a> [ibmcloud\_api\_key](#input\_ibmcloud\_api\_key) | An IBM Cloud API key with permissions to provision resources. | `string` | n/a | yes |
 | <a name="input_ignore_worker_pool_size_changes"></a> [ignore\_worker\_pool\_size\_changes](#input\_ignore\_worker\_pool\_size\_changes) | Enable if using worker autoscaling. Stops Terraform managing worker count | `bool` | `false` | no |
 | <a name="input_kms_account_id"></a> [kms\_account\_id](#input\_kms\_account\_id) | Id of the account that owns the KMS instance to encrypt the cluster. It is only required if the KMS instance is in another account. | `string` | `null` | no |
 | <a name="input_kms_use_private_endpoint"></a> [kms\_use\_private\_endpoint](#input\_kms\_use\_private\_endpoint) | Set as true to use the Private endpoint when communicating between cluster and KMS instance. | `bool` | `true` | no |
+| <a name="input_kms_wait_for_apply"></a> [kms\_wait\_for\_apply](#input\_kms\_wait\_for\_apply) | Set true to make terraform wait until KMS is applied to master and it is ready and deployed. Default value is true. | `bool` | `true` | no |
 | <a name="input_log_analysis_add_cluster_name"></a> [log\_analysis\_add\_cluster\_name](#input\_log\_analysis\_add\_cluster\_name) | If true, configure the log analysis agent to attach a tag containing the cluster name to all log messages. | `bool` | `true` | no |
 | <a name="input_log_analysis_agent_custom_line_exclusion"></a> [log\_analysis\_agent\_custom\_line\_exclusion](#input\_log\_analysis\_agent\_custom\_line\_exclusion) | Log Analysis agent custom configuration for line exclusion setting LOGDNA\_K8S\_METADATA\_LINE\_EXCLUSION. See https://github.com/logdna/logdna-agent-v2/blob/master/docs/KUBERNETES.md#configuration-for-kubernetes-metadata-filtering for more info. | `string` | `null` | no |
 | <a name="input_log_analysis_agent_custom_line_inclusion"></a> [log\_analysis\_agent\_custom\_line\_inclusion](#input\_log\_analysis\_agent\_custom\_line\_inclusion) | Log Analysis agent custom configuration for line inclusion setting LOGDNA\_K8S\_METADATA\_LINE\_INCLUSION. See https://github.com/logdna/logdna-agent-v2/blob/master/docs/KUBERNETES.md#configuration-for-kubernetes-metadata-filtering for more info. | `string` | `null` | no |

--- a/examples/end-to-end-example/main.tf
+++ b/examples/end-to-end-example/main.tf
@@ -192,7 +192,6 @@ locals {
 
 module "ocp_all_inclusive" {
   source                           = "../.."
-  ibmcloud_api_key                 = var.ibmcloud_api_key
   resource_group_id                = module.resource_group.resource_group_id
   region                           = var.region
   cluster_name                     = "${var.prefix}-cluster"

--- a/examples/end-to-end-example/version.tf
+++ b/examples/end-to-end-example/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.64.0"
+      version = ">= 1.66.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/main.tf
+++ b/main.tf
@@ -17,12 +17,13 @@ locals {
     instance_id      = var.existing_kms_instance_guid
     private_endpoint = var.kms_use_private_endpoint
     account_id       = var.kms_account_id
+    wait_for_apply   = var.kms_wait_for_apply
   } : null
 }
 
 module "ocp_base" {
   source                              = "terraform-ibm-modules/base-ocp-vpc/ibm"
-  version                             = "3.25.5"
+  version                             = "3.27.1"
   cluster_name                        = var.cluster_name
   ocp_version                         = var.ocp_version
   resource_group_id                   = var.resource_group_id
@@ -45,7 +46,6 @@ module "ocp_base" {
   number_of_lbs                       = var.number_of_lbs
   additional_vpe_security_group_ids   = var.additional_vpe_security_group_ids
   kms_config                          = local.kms_config
-  ibmcloud_api_key                    = var.ibmcloud_api_key
   addons                              = var.addons
   manage_all_addons                   = var.manage_all_addons
   verify_worker_network_readiness     = var.verify_worker_network_readiness

--- a/variables.tf
+++ b/variables.tf
@@ -2,12 +2,6 @@
 # Common Variables
 ##############################################################################
 
-variable "ibmcloud_api_key" {
-  description = "An IBM Cloud API key with permissions to provision resources."
-  type        = string
-  sensitive   = true
-}
-
 variable "resource_group_id" {
   type        = string
   description = "The IBM Cloud resource group ID to provision all resources in."
@@ -311,6 +305,12 @@ variable "kms_account_id" {
   type        = string
   description = "Id of the account that owns the KMS instance to encrypt the cluster. It is only required if the KMS instance is in another account."
   default     = null
+}
+
+variable "kms_wait_for_apply" {
+  type        = bool
+  description = "Set true to make terraform wait until KMS is applied to master and it is ready and deployed. Default value is true."
+  default     = true
 }
 
 ##############################################################################

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.64.0, < 2.0.0"
+      version = ">= 1.66.0, < 2.0.0"
     }
     # tflint-ignore: terraform_unused_required_providers
     external = {


### PR DESCRIPTION
### Description

- added new variable `kms_wait_for_apply`
- updated to latest base OCP module which no longer has a `ibmcloud_api_key` input

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
