### PR TITLE
Fixed ACLs for openshift console in end-to-end example

### DIFF
--- a/examples/end-to-end-example/README.md
+++ b/examples/end-to-end-example/README.md
@@ -3,7 +3,9 @@
 An end-to-end example that will:
 - Create a new resource group (if existing one is not passed in).
 - Provision a VPC in the given resource group and region.
-- Define ACLs to allow inbound and outboud traffic from/to Ingress Operator to correctly report cluster ingress status
+- Define ACLs to allow inbound and outboud traffic:
+  - from/to Ingress Operator to correctly report cluster ingress status
+  - to the cluster's oAuth server port to enable the Openshift cluster console
 - Provision Log Analysis and Cloud Monitoring instances in the given resource group and region.
 - Provision a Key Protect instance in the given resource group and region and create a new key ring and key in the instance
 - Call the ocp-all-inclusive-module to do the following:

--- a/examples/end-to-end-example/main.tf
+++ b/examples/end-to-end-example/main.tf
@@ -98,7 +98,7 @@ locals {
       add_ibm_cloud_internal_rules = true
       add_vpc_connectivity_rules   = true
       prepend_ibm_rules            = true
-      rules                        = var.allow_ingress_console_traffic == true ? setunion(local.acl_rules_ingress_healthcheck_operator, local.acl_rules_openshift_console_oauth) : []
+      rules                        = setunion(local.acl_rules_ingress_healthcheck_operator, local.acl_rules_openshift_console_oauth)
     }
   ]
 }

--- a/examples/end-to-end-example/variables.tf
+++ b/examples/end-to-end-example/variables.tf
@@ -69,3 +69,9 @@ variable "disable_public_endpoint" {
   description = "Whether access to the public service endpoint is disabled when the cluster is created. Does not affect existing clusters. To change a public endpoint to private, create another cluster with the variable set to true or see [Switching to the private endpoint](https://cloud.ibm.com/docs/containers?topic=containers-cs_network_cluster#migrate-to-private-se)."
   default     = false
 }
+
+variable "allow_ingress_console_traffic" {
+  type        = bool
+  description = "Set this flag to true to allow the OpenShift Ingress operator healthcheck and OpenShift console oAuth traffic. Set to false to restrict allowed traffic policies, resulting in degraded Ingress status and Openshift console not accessible from the browser."
+  default     = true
+}

--- a/examples/end-to-end-example/variables.tf
+++ b/examples/end-to-end-example/variables.tf
@@ -69,9 +69,3 @@ variable "disable_public_endpoint" {
   description = "Whether access to the public service endpoint is disabled when the cluster is created. Does not affect existing clusters. To change a public endpoint to private, create another cluster with the variable set to true or see [Switching to the private endpoint](https://cloud.ibm.com/docs/containers?topic=containers-cs_network_cluster#migrate-to-private-se)."
   default     = false
 }
-
-variable "allow_ingress_console_traffic" {
-  type        = bool
-  description = "Set this flag to true to allow the OpenShift Ingress operator healthcheck and OpenShift console oAuth traffic. Set to false to restrict allowed traffic policies, resulting in degraded Ingress status and Openshift console not accessible from the browser."
-  default     = true
-}


### PR DESCRIPTION
### Description

Added ACLs to allow openshift console pods to reach oAuth server in order to start successfully and added flag to disable these ACLs, including ingress healthcheck operator ones, in end-to-end example

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added ACLs to allow openshift console pods to reach oAuth server in order to start successfully in end-to-end example
Added flag to disable these ACLs, including ingress healthcheck operator ones in end-to-end example

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [X] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
